### PR TITLE
Fix issue #2: Replace file content dump with file reference only

### DIFF
--- a/context-bridge.lua
+++ b/context-bridge.lua
@@ -238,14 +238,36 @@ function M.send_line()
   send_to_agent(text, context, current_line, current_line)
 end
 
--- Send entire file
+-- Send file path reference
 function M.send_file()
-  local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-  local text = table.concat(lines, '\n')
-  local total_lines = vim.fn.line('$')
-  
+  local relative_filename = vim.fn.expand('%')
   local context = get_context_input()
-  send_to_agent(text, context, 1, total_lines)
+  
+  -- Get the tmux pane
+  local pane_id = M.get_agent_pane(false)
+  if not pane_id then
+    vim.notify("Error: Could not find agent tmux pane", vim.log.levels.ERROR)
+    return false
+  end
+  
+  -- Build simple message
+  local message = ''
+  if context and context ~= '' then
+    message = context .. '\n\n'
+  end
+  message = message .. 'File: ' .. relative_filename
+  
+  -- Clear input and send
+  os.execute('tmux send-keys -t ' .. pane_id .. ' C-c')
+  vim.wait(200)
+  
+  local escaped_message = message:gsub("'", "'\"'\"'")
+  os.execute(string.format("tmux send-keys -t %s -l '%s'", pane_id, escaped_message))
+  
+  vim.wait(100)
+  os.execute('tmux send-keys -t ' .. pane_id .. ' Enter')
+  
+  vim.notify('Sent file reference to agent (pane ' .. pane_id .. ')', vim.log.levels.INFO)
 end
 
 -- Send a specific range
@@ -298,7 +320,7 @@ function M._setup_keymaps()
   if keymaps.file_send then
     vim.keymap.set('n', keymaps.file_send, function()
       M.send_file()
-    end, { desc = 'Send entire file to agent' })
+    end, { desc = 'Send file reference to agent' })
   end
 end
 


### PR DESCRIPTION
## Summary
- Replaces the file content dumping behavior with a simple file reference
- Modified `send_file()` to send only the file path instead of full contents
- Eliminates token waste and performance issues with large files

## Changes Made
- **send_file() function**: Now sends only `File: [filename]` with optional context
- **Removed file reading**: No longer reads or sends file contents
- **Updated keymap description**: Changed from "Send entire file" to "Send file reference"
- **Simplified message format**: Clean output like `File: context-bridge.lua`

## Test Plan
- [x] Test `<leader>cf` sends only file path (not contents)
- [x] Test with various file types and sizes
- [x] Verify context/question functionality still works
- [x] Confirm tmux communication works correctly

## Impact
✅ **Fixes token waste from large file dumps**  
✅ **Improves performance for large files**  
✅ **Cleaner, more focused AI agent interactions**  
✅ **Maintains backward compatibility for keymaps/commands**

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)